### PR TITLE
Cubism 4 SDK for Web R5 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.5-beta.3] - 2022-06-16
+
+### Fixed
+
+* Fix a problem in which ViewPort was sometimes not set correctly.
+
+### Removed
+
+* End support for Internet Explorer.
+
+
 ## [4-r.5-beta.2] - 2022-06-02
 
 ### Fixed
@@ -117,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue with reloading model images in WebKit.
 
 
+[4-r.5-beta.3]: https://github.com/Live2D/CubismWebSamples/compare/4-r.5-beta.2...4-r.5-beta.3
 [4-r.5-beta.2]: https://github.com/Live2D/CubismWebSamples/compare/4-r.5-beta.1...4-r.5-beta.2
 [4-r.5-beta.1]: https://github.com/Live2D/CubismWebSamples/compare/4-r.4...4-r.5-beta.1
 [4-r.4]: https://github.com/Live2D/CubismWebSamples/compare/4-r.3...4-r.4

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ NOTE: デバック用の設定は、`.vscode/launch.json` に記述していま�
 
 | プラットフォーム | ブラウザ | バージョン |
 | --- | --- | --- |
-| Android | Google Chrome | 101.0.4951.61 |
+| Android | Google Chrome | 102.0.5005.115 |
 | Android | Microsoft Edge | 101.0.1210.47 |
 | Android | Mozilla Firefox | 100.1.2 |
 | iOS / iPadOS | Google Chrome | 101.0.4951.58 |
@@ -100,9 +100,8 @@ NOTE: デバック用の設定は、`.vscode/launch.json` に記述していま�
 | macOS | Google Chrome | 101.0.4951.64 |
 | macOS | Microsoft Edge | 101.0.1210.47 |
 | macOS | Mozilla Firefox | 100.0.1 |
-| macOS | Safari | 15.4 |
-| Windows | Google Chrome | 101.0.4951.67 |
-| Windows | Internet Explorer 11 | 19044.1645 |
+| macOS | Safari | 15.5 |
+| Windows | Google Chrome | 102.0.5005.115 |
 | Windows | Microsoft Edge | 101.0.1210.47 |
 | Windows | Mozilla Firefox | 100.0 |
 

--- a/Samples/TypeScript/Demo/src/lappdelegate.ts
+++ b/Samples/TypeScript/Demo/src/lappdelegate.ts
@@ -118,6 +118,11 @@ export class LAppDelegate {
     this._resizeCanvas();
     this._view.initialize();
     this._view.initializeSprite();
+
+    // キャンバスサイズを渡す
+    const viewport: number[] = [0, 0, canvas.width, canvas.height];
+
+    gl.viewport(viewport[0], viewport[1], viewport[2], viewport[3]);
   }
 
   /**


### PR DESCRIPTION
### Fixed

* Fix a problem in which ViewPort was sometimes not set correctly.

### Removed

* End support for Internet Explorer.