### PR TITLE
Update to Cubism 4 SDK for Web R6_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.6.2] - 2023-03-16
+
+### Fixed
+
+* Fix some problems related to Cubism Core.
+  * See `CHANGELOG.md` in Core.
+
+
 ## [4-r.6.1] - 2023-03-10
 
 ### Added
@@ -169,6 +177,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue with reloading model images in WebKit.
 
 
+[4-r.6.2]: https://github.com/Live2D/CubismWebSamples/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismWebSamples/compare/4-r.6...4-r.6.1
 [4-r.6]: https://github.com/Live2D/CubismWebSamples/compare/4-r.5...4-r.6
 [4-r.5]: https://github.com/Live2D/CubismWebSamples/compare/4-r.5-beta.5...4-r.5

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2023-03-16
+
+### Fixed
+
+* Fix a case in which the index of the mask's drawable object was negative value for `csmGetDrawableMasks()`.
+* Fix a problem in which `csmHasMocConsistency()` was returned as 0 even though the MOC3 file was in the correct format.
+  * This problem was occurring in some models using the blendshape weight limit settings.
+* Fix a problem that could cause a crash if a MOC3 file that is not in the correct format is loaded with `csmHasMocConsistency()`.
+
+### Changed
+
+* Upgrade Core version to 04.02.0004.
+
+
 ## 2023-03-10
 
 ### Added


### PR DESCRIPTION
### Fixed

* Fix some problems related to Cubism Core.
  * See `CHANGELOG.md` in Core.