### PR TITLE
Fix blurry image on mobile devices (especially in fullscreen mode)

### DIFF
--- a/Samples/TypeScript/Demo/index.html
+++ b/Samples/TypeScript/Demo/index.html
@@ -2,12 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=1900">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TypeScript HTML App</title>
   <style>
     html, body {
         margin: 0;
         overflow: hidden;
+    }
+    canvas {
+        width: 100vw;
+        height: 100vh;
+        display: block;
     }
   </style>
   <!-- Pollyfill script -->

--- a/Samples/TypeScript/Demo/src/lappdelegate.ts
+++ b/Samples/TypeScript/Demo/src/lappdelegate.ts
@@ -54,12 +54,6 @@ export class LAppDelegate {
   public initialize(): boolean {
     // キャンバスの作成
     canvas = document.createElement('canvas');
-    if (LAppDefine.CanvasSize === 'auto') {
-      this._resizeCanvas();
-    } else {
-      canvas.width = LAppDefine.CanvasSize.width;
-      canvas.height = LAppDefine.CanvasSize.height;
-    }
 
     // glコンテキストを初期化
     // @ts-ignore
@@ -78,6 +72,13 @@ export class LAppDelegate {
 
     // キャンバスを DOM に追加
     document.body.appendChild(canvas);
+
+    if (LAppDefine.CanvasSize === 'auto') {
+      this._resizeCanvas();
+    } else {
+      canvas.width = LAppDefine.CanvasSize.width;
+      canvas.height = LAppDefine.CanvasSize.height;
+    }
 
     if (!frameBuffer) {
       frameBuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
@@ -118,11 +119,6 @@ export class LAppDelegate {
     this._resizeCanvas();
     this._view.initialize();
     this._view.initializeSprite();
-
-    // キャンバスサイズを渡す
-    const viewport: number[] = [0, 0, canvas.width, canvas.height];
-
-    gl.viewport(viewport[0], viewport[1], viewport[2], viewport[3]);
   }
 
   /**
@@ -294,8 +290,9 @@ export class LAppDelegate {
    * Resize the canvas to fill the screen.
    */
   private _resizeCanvas(): void {
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    canvas.width  = canvas.clientWidth  * window.devicePixelRatio;
+    canvas.height = canvas.clientHeight * window.devicePixelRatio;
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
   }
 
   _cubismOption: Option; // Cubism SDK Option

--- a/Samples/TypeScript/Demo/src/lappview.ts
+++ b/Samples/TypeScript/Demo/src/lappview.ts
@@ -176,7 +176,7 @@ export class LAppView {
    * @param pointY スクリーンY座標
    */
   public onTouchesBegan(pointX: number, pointY: number): void {
-    this._touchManager.touchesBegan(pointX, pointY);
+    this._touchManager.touchesBegan(pointX * window.devicePixelRatio, pointY * window.devicePixelRatio);
   }
 
   /**
@@ -189,7 +189,7 @@ export class LAppView {
     const viewX: number = this.transformViewX(this._touchManager.getX());
     const viewY: number = this.transformViewY(this._touchManager.getY());
 
-    this._touchManager.touchesMoved(pointX, pointY);
+    this._touchManager.touchesMoved(pointX * window.devicePixelRatio, pointY * window.devicePixelRatio);
 
     const live2DManager: LAppLive2DManager = LAppLive2DManager.getInstance();
     live2DManager.onDrag(viewX, viewY);
@@ -221,7 +221,7 @@ export class LAppView {
       live2DManager.onTap(x, y);
 
       // 歯車にタップしたか
-      if (this._gear.isHit(pointX, pointY)) {
+      if (this._gear.isHit(pointX * window.devicePixelRatio, pointY * window.devicePixelRatio)) {
         live2DManager.nextScene();
       }
     }


### PR DESCRIPTION
Fix `canvas.width` and `canvas.height` for mobile devices.

When you go fullscreen **without** this fix, meta `content="width=1900"` stops working and image becomes awfully blurry and low resolution. Similar effect is also a bit visible in landscape orientation without fullscreen mode (when 1900 is not enough).

Examples:

**Without fix**
![1_before](https://github.com/Live2D/CubismWebSamples/assets/213696/312bcc83-7df3-4356-97f9-4bf7e3b83a5b)

**With fix**
![1_after](https://github.com/Live2D/CubismWebSamples/assets/213696/bcd49eef-fbd5-4141-9677-53af6d4be5a2)

**Without fix**
![2_before](https://github.com/Live2D/CubismWebSamples/assets/213696/a427b766-fc35-4222-87a7-78d4b0d4d023)

**With fix**
![2_after](https://github.com/Live2D/CubismWebSamples/assets/213696/a0b97678-1617-47bc-bada-7377eefe203c)
